### PR TITLE
Prompt the user for the new password

### DIFF
--- a/playbooks/password-change.yml
+++ b/playbooks/password-change.yml
@@ -1,12 +1,14 @@
-  #ansible-playbook ./playbooks/password-change.yml --user someuser --ask-become-pass -i ./inventory/hosts --extra-vars newpassword=P@ssword!!(replace)
-  - name: password change
-    hosts: "*"
-    become: true
-    tasks:
-    - name: change user's password
-      user:
-        name: someuser
-        update_password: always
-        password: "{{ newpassword|password_hash('sha512') }}"
-
+#ansible-playbook ./playbooks/password-change.yml --user someuser --ask-become-pass -i ./inventory/hosts
+- name: password change
+  hosts: "*"
+  become: true
+  vars_prompt:
+  - name: new_password
+    prompt: "Enter new password"
+  tasks:
+  - name: change user's password
+    user:
+      name: "{{ ansible_user }}"
+      update_password: always
+      password: "{{ new_password|password_hash('sha512') }}"
 


### PR DESCRIPTION
Hi, thanks for your inspiring video!
I've got a similar playbook for changing passwords where I use a prompt so the password doesn't get saved into the shell history.

This commit adds that feature and also
- Removes unnecessary intentation
- Use the user variable instead of using a constant

Any thoughts?